### PR TITLE
Added robustness against DOM changes

### DIFF
--- a/jquery.svgInject.js
+++ b/jquery.svgInject.js
@@ -8,6 +8,7 @@
 
 ;(function($, window, document, undefined) {
     var pluginName = 'svgInject';
+	var injectIdx=0;
 
     /**
      * Cache that helps to reduce requests
@@ -139,7 +140,8 @@
             var imgID = $el.attr('id');
             var imgClass = $el.attr('class');
             var imgData = $el.clone(true).data();
-
+			var key='injectKey-'+(injectIdx++);
+			$el.addClass(key);
             var dimensions = {
                 w: $el.attr('width'),
                 h: $el.attr('height')
@@ -158,6 +160,7 @@
 
             // We add an entry to the cache with the given image url
             this._cache.addEntry(imgURL , function( svg ){
+				var $el=$('.'+key);
                 // When the entry is loaded, the image gets replaces by the clone of the loaded svg
                 _this.replaceIMGWithSVG($el, svg.clone(), imgID, imgClass, imgURL, imgData, dimensions, callback);
             });


### PR DESCRIPTION
SVG injection was not working well for several cases.
This happene in a jQuery-UI button.
jQuery-UI redefines the DOM element by wrapping it inside other DOM elements.  As a result "this.element" is no longer referencing a DOM element by the time the SVG is loaded.
In order to make svgInject robust against this, this modification adds a unique class to the original element and the replacement is performed by using this class as the specifier.